### PR TITLE
Improved control rendering

### DIFF
--- a/CefSharp.WpfExample/MainWindow.xaml.cs
+++ b/CefSharp.WpfExample/MainWindow.xaml.cs
@@ -15,6 +15,12 @@ namespace CefSharp.WpfExample
         public MainWindow()
         {
             InitializeComponent();
+            Application.Current.Exit += OnApplicationExit;
+        }
+
+        private void OnApplicationExit(object sender, ExitEventArgs e)
+        {
+            CEF.Shutdown();
         }
 
         private void Window_SourceInitialized(object sender, EventArgs e)

--- a/CefSharp/CefWpfWebBrowser.cpp
+++ b/CefSharp/CefWpfWebBrowser.cpp
@@ -206,14 +206,11 @@ namespace CefSharp
 
     Size CefWpfWebBrowser::ArrangeOverride(Size size)
     {
-        try
-        {
-            _clientAdapter->GetCefBrowser()->SetSize(PET_VIEW, (int)size.Width, (int)size.Height);
-        }
-        catch (...)
-        {
-            // ArrangeOverride may be called one or more times before Cef is initialized
-        }
+		if(_clientAdapter->GetIsInitialized()) {
+			_clientAdapter->GetCefBrowser()->SetSize(PET_VIEW, (int)size.Width, (int)size.Height);
+		} else {
+			Dispatcher->BeginInvoke(DispatcherPriority::Loaded, gcnew ActionDelegate(this, &CefWpfWebBrowser::InvalidateArrange));
+		}
 
         return ContentControl::ArrangeOverride(size);
     }
@@ -343,37 +340,74 @@ namespace CefSharp
 
     void CefWpfWebBrowser::SetBuffer(int width, int height, const CefRect& dirtyRect, const void* buffer)
     {
-        _width = width;
-        _height = height;
-        _buffer = (void *)buffer;
-
-        Dispatcher->Invoke(DispatcherPriority::Render,
-            gcnew Action<WriteableBitmap^>(this, &CefWpfWebBrowser::SetBitmap), _bitmap);
-    }
-
-    // XXX: don't know how to Invoke a parameterless delegate...
-    void CefWpfWebBrowser::SetBitmap(WriteableBitmap^ bitmap)
-    {
-        int length = _width * _height * 4;
-
-        if (length == 0)
+		if (dirtyRect.width == 0 || dirtyRect.height == 0 || width == 0 || height == 0)
         {
             return;
         }
 
-        if (!_bitmap ||
-            _bitmap->PixelWidth != _width ||
-            _bitmap->PixelHeight != _height)
+        if (!_backBufferHandle || _width != width || _height != height)
         {
-            _image->Source = _bitmap = gcnew WriteableBitmap(_width, _height, 96 * _transform.M11, 96 * _transform.M22, PixelFormats::Bgr32, nullptr);
+			_ibitmap = nullptr;
+
+			if (_backBufferHandle)
+            {
+                UnmapViewOfFile(_backBufferHandle);
+                _backBufferHandle = NULL;
+            }
+
+            if (_fileMappingHandle)
+            {
+                CloseHandle(_fileMappingHandle);
+                _fileMappingHandle = NULL;
+            }
+
+			int pixels = width * height;
+            int bytes = pixels * PixelFormats::Bgr32.BitsPerPixel / 8;
+
+			_fileMappingHandle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, bytes, NULL);
+			if(!_fileMappingHandle) 
+			{
+				return;
+			}
+
+			_backBufferHandle = MapViewOfFile(_fileMappingHandle, FILE_MAP_ALL_ACCESS, 0, 0, bytes);
+			if(!_backBufferHandle) 
+			{
+				return;
+			}
+
+			_width = width;
+			_height = height;
         }
-
-        Int32Rect rect;
-        rect.X = 0;
-        rect.Y = 0;
-        rect.Width = _width;
-        rect.Height = _height;
-
-        _bitmap->WritePixels(rect, (IntPtr)_buffer, length, _bitmap->BackBufferStride);
+	
+		int stride = width * PixelFormats::Bgr32.BitsPerPixel / 8;
+		CopyMemory(_backBufferHandle, (void*) buffer, height * stride);
+		
+		if(!Dispatcher->HasShutdownStarted) {
+			Dispatcher->BeginInvoke(DispatcherPriority::Render, _paintDelegate);
+		}
     }
+    
+	void CefWpfWebBrowser::SetBitmap()
+    {
+		InteropBitmap^ bitmap = _ibitmap;
+
+		if(bitmap == nullptr) 
+		{
+			_image->Source = nullptr;
+			GC::Collect(1);
+
+			int stride = _width * PixelFormats::Bgr32.BitsPerPixel / 8;
+			bitmap = (InteropBitmap^) System::Windows::Interop::Imaging::CreateBitmapSourceFromMemorySection((IntPtr) _fileMappingHandle, _width, _height, PixelFormats::Bgr32, stride, 0);
+			_image->Source = bitmap;
+			_ibitmap = bitmap;
+		}
+
+		bitmap->Invalidate();
+    }
+
+	void CefWpfWebBrowser::Close() 
+	{
+		_clientAdapter->GetCefBrowser()->CloseBrowser();
+	}
 }

--- a/CefSharp/CefWpfWebBrowser.h
+++ b/CefSharp/CefWpfWebBrowser.h
@@ -24,6 +24,8 @@ namespace CefSharp
     [TemplatePart(Name="PART_Browser", Type=System::Windows::Controls::Image::typeid)]
     public ref class CefWpfWebBrowser sealed : public ContentControl, ICefWebBrowser
     {
+		delegate void ActionDelegate();
+
         bool _canGoForward;
         bool _canGoBack;
         bool _isLoading;
@@ -47,12 +49,14 @@ namespace CefSharp
 
         Matrix _transform;
         int _width, _height;
-        void *_buffer;
-        WriteableBitmap^ _bitmap;
+        InteropBitmap^ _ibitmap;
+		HANDLE _fileMappingHandle, _backBufferHandle;
+		ActionDelegate^ _paintDelegate;
 
     private:
         void SetCursor(SafeFileHandle^ handle);
         IntPtr SourceHook(IntPtr hWnd, int message, IntPtr wParam, IntPtr lParam, bool% handled);
+		void SetBitmap();
 
     protected:
         virtual Size ArrangeOverride(Size size) override;
@@ -70,8 +74,6 @@ namespace CefSharp
             Focusable = true;
             FocusVisualStyle = nullptr;
 
-
-
             if (!CEF::IsInitialized)
             {
                 throw gcnew InvalidOperationException("CEF is not initialized");
@@ -82,6 +84,7 @@ namespace CefSharp
             _browserInitialized = gcnew ManualResetEvent(false);
             _loadCompleted = gcnew RtzCountdownEvent();
             _transform = source->CompositionTarget->TransformToDevice;
+			_paintDelegate = gcnew ActionDelegate(this, &CefWpfWebBrowser::SetBitmap);
 
             source->AddHook(gcnew Interop::HwndSourceHook(this, &CefWpfWebBrowser::SourceHook));
 
@@ -192,7 +195,7 @@ namespace CefSharp
         event ConsoleMessageEventHandler^ ConsoleMessage;
 
         void SetCursor(CefCursorHandle cursor);
-        void SetBuffer(int width, int height, const CefRect& dirtyRect, const void* buffer);
-        void SetBitmap(WriteableBitmap^ bitmap);
+		void SetBuffer(int width, int height, const CefRect& dirtyRect, const void* buffer);
+		void Close();
     };
 }


### PR DESCRIPTION
Improved control rendering using a InteropBitmap instead of a WriteableBitmap. According to my tests and measures this uses a little less CPU and memory but a little more GPU memory - at the end of the day this is better. Also allows changes to the image buffer in other threads other than the UI thread and fixes application dead-locks when running Javascript at the same time of render.
Fixed a problem with arrange when the browser was not initialized which could lead to no image at all.
Added CEF graceful shutdown call.
