### PR TITLE
Implemented LoadHtml/LoadString

### DIFF
--- a/CefSharp.Example/ExamplePresenter.cs
+++ b/CefSharp.Example/ExamplePresenter.cs
@@ -69,6 +69,7 @@ namespace CefSharp.Example
             view.TestConsoleMessageActivated += view_TestConsoleMessageActivated;
             view.TestTooltipActivated += view_TestTooltipActivated;
             view.TestPopupActivated += view_TestPopupActivated;
+            view.TestLoadStringActivated += view_TestLoadStringActivated;
 
             // navigation
             view.UrlActivated += view_UrlActivated;
@@ -214,6 +215,11 @@ namespace CefSharp.Example
         private void view_TestPopupActivated(object sender, EventArgs e)
         {
             model.Load(popup_url);
+        }
+
+        private void view_TestLoadStringActivated(object sender, EventArgs e)
+        {
+            model.LoadHtml(string.Format("<html><body><a href='{0}'>CefSharp Home</a></body></html>", home_url));
         }
 
         private void view_UrlActivated(object sender, string url)

--- a/CefSharp.Example/IExampleView.cs
+++ b/CefSharp.Example/IExampleView.cs
@@ -25,6 +25,7 @@ namespace CefSharp.Example
         event EventHandler TestConsoleMessageActivated;
         event EventHandler TestTooltipActivated;
         event EventHandler TestPopupActivated;
+        event EventHandler TestLoadStringActivated;
 
         // navigation
         event Action<object, string> UrlActivated;

--- a/CefSharp.WinForms.Example/Browser.Designer.cs
+++ b/CefSharp.WinForms.Example/Browser.Designer.cs
@@ -40,6 +40,15 @@
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.undoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.redoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.cutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pasteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testResourceLoadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testSchemeLoadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -49,15 +58,7 @@
             this.testConsoleMessageMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testTooltipMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.testPopupMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.undoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.redoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.cutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.pasteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.testLoadStringMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripContainer.ContentPanel.SuspendLayout();
             this.toolStripContainer.TopToolStripPanel.SuspendLayout();
             this.toolStripContainer.SuspendLayout();
@@ -169,15 +170,77 @@
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.AboutToolStripMenuItemClick);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
             this.exitToolStripMenuItem.Text = "Exit";
+            // 
+            // editToolStripMenuItem
+            // 
+            this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.undoMenuItem,
+            this.redoMenuItem,
+            this.toolStripMenuItem2,
+            this.cutMenuItem,
+            this.copyMenuItem,
+            this.pasteMenuItem,
+            this.deleteMenuItem,
+            this.selectAllMenuItem});
+            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
+            this.editToolStripMenuItem.Text = "Edit";
+            // 
+            // undoMenuItem
+            // 
+            this.undoMenuItem.Name = "undoMenuItem";
+            this.undoMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.undoMenuItem.Text = "Undo";
+            // 
+            // redoMenuItem
+            // 
+            this.redoMenuItem.Name = "redoMenuItem";
+            this.redoMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.redoMenuItem.Text = "Redo";
+            // 
+            // toolStripMenuItem2
+            // 
+            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(119, 6);
+            // 
+            // cutMenuItem
+            // 
+            this.cutMenuItem.Name = "cutMenuItem";
+            this.cutMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.cutMenuItem.Text = "Cut";
+            // 
+            // copyMenuItem
+            // 
+            this.copyMenuItem.Name = "copyMenuItem";
+            this.copyMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.copyMenuItem.Text = "Copy";
+            // 
+            // pasteMenuItem
+            // 
+            this.pasteMenuItem.Name = "pasteMenuItem";
+            this.pasteMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.pasteMenuItem.Text = "Paste";
+            // 
+            // deleteMenuItem
+            // 
+            this.deleteMenuItem.Name = "deleteMenuItem";
+            this.deleteMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.deleteMenuItem.Text = "Delete";
+            // 
+            // selectAllMenuItem
+            // 
+            this.selectAllMenuItem.Name = "selectAllMenuItem";
+            this.selectAllMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.selectAllMenuItem.Text = "Select All";
             // 
             // testsToolStripMenuItem
             // 
@@ -189,7 +252,8 @@
             this.testBindMenuItem,
             this.testConsoleMessageMenuItem,
             this.testTooltipMenuItem,
-            this.testPopupMenuItem});
+            this.testPopupMenuItem,
+            this.testLoadStringMenuItem});
             this.testsToolStripMenuItem.Name = "testsToolStripMenuItem";
             this.testsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
             this.testsToolStripMenuItem.Text = "Tests";
@@ -242,67 +306,11 @@
             this.testPopupMenuItem.Size = new System.Drawing.Size(254, 22);
             this.testPopupMenuItem.Text = "Test Popup";
             // 
-            // editToolStripMenuItem
+            // testLoadStringMenuItem
             // 
-            this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.undoMenuItem,
-            this.redoMenuItem,
-            this.toolStripMenuItem2,
-            this.cutMenuItem,
-            this.copyMenuItem,
-            this.pasteMenuItem,
-            this.deleteMenuItem,
-            this.selectAllMenuItem});
-            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
-            this.editToolStripMenuItem.Text = "Edit";
-            // 
-            // undoMenuItem
-            // 
-            this.undoMenuItem.Name = "undoMenuItem";
-            this.undoMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.undoMenuItem.Text = "Undo";
-            // 
-            // redoMenuItem
-            // 
-            this.redoMenuItem.Name = "redoMenuItem";
-            this.redoMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.redoMenuItem.Text = "Redo";
-            // 
-            // cutMenuItem
-            // 
-            this.cutMenuItem.Name = "cutMenuItem";
-            this.cutMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.cutMenuItem.Text = "Cut";
-            // 
-            // copyMenuItem
-            // 
-            this.copyMenuItem.Name = "copyMenuItem";
-            this.copyMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.copyMenuItem.Text = "Copy";
-            // 
-            // pasteMenuItem
-            // 
-            this.pasteMenuItem.Name = "pasteMenuItem";
-            this.pasteMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.pasteMenuItem.Text = "Paste";
-            // 
-            // deleteMenuItem
-            // 
-            this.deleteMenuItem.Name = "deleteMenuItem";
-            this.deleteMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.deleteMenuItem.Text = "Delete";
-            // 
-            // selectAllMenuItem
-            // 
-            this.selectAllMenuItem.Name = "selectAllMenuItem";
-            this.selectAllMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.selectAllMenuItem.Text = "Select All";
-            // 
-            // toolStripMenuItem2
-            // 
-            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(149, 6);
+            this.testLoadStringMenuItem.Name = "testLoadStringMenuItem";
+            this.testLoadStringMenuItem.Size = new System.Drawing.Size(254, 22);
+            this.testLoadStringMenuItem.Text = "Test Load String";
             // 
             // Browser
             // 
@@ -352,6 +360,7 @@
         private System.Windows.Forms.Label outputLabel;
         private System.Windows.Forms.ToolStripMenuItem testTooltipMenuItem;
         private System.Windows.Forms.ToolStripMenuItem testPopupMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem testLoadStringMenuItem;
         private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem undoMenuItem;
         private System.Windows.Forms.ToolStripMenuItem redoMenuItem;

--- a/CefSharp.WinForms.Example/Browser.cs
+++ b/CefSharp.WinForms.Example/Browser.cs
@@ -102,6 +102,12 @@ namespace CefSharp.WinForms.Example
             remove { testPopupMenuItem.Click -= value; }
         }
 
+        public event EventHandler TestLoadStringActivated
+        {
+            add { testLoadStringMenuItem.Click += value; }
+            remove { testLoadStringMenuItem.Click -= value; }
+        }
+
 
         public event Action<object, string> UrlActivated;
 

--- a/CefSharp.WinForms/WebView.cpp
+++ b/CefSharp.WinForms/WebView.cpp
@@ -77,6 +77,13 @@ namespace WinForms
         _clientAdapter->GetCefBrowser()->GetMainFrame()->LoadURL(toNative(url));
     }
 
+    void WebView::LoadHtml(String^ html)
+    {
+        _browserCore->CheckBrowserInitialization();
+        _browserCore->OnLoad();
+        _clientAdapter->GetCefBrowser()->GetMainFrame()->LoadString(toNative(html), toNative("about:blank"));
+    }
+
     void WebView::Stop()
     {
         _browserCore->CheckBrowserInitialization();

--- a/CefSharp.WinForms/WebView.h
+++ b/CefSharp.WinForms/WebView.h
@@ -146,6 +146,7 @@ namespace WinForms
         virtual void OnInitialized();
 
         virtual void Load(String^ url);
+        virtual void LoadHtml(String^ html);
         virtual void Stop();
         virtual void Back();
         virtual void Forward();

--- a/CefSharp.Wpf.Example/MainWindow.xaml
+++ b/CefSharp.Wpf.Example/MainWindow.xaml
@@ -27,6 +27,7 @@
                 <MenuItem Header="Test Console Message" Name="testConsoleMessageMenuItem" Click="control_Activated" />
                 <MenuItem Header="Test Tooltip" Name="testTooltipMenuItem" Click="control_Activated" />
                 <MenuItem Header="Test Popup" Name="testPopupMenuItem" Click="control_Activated" />
+                <MenuItem Header="Test Load String" Name="testLoadStringItem" Click="control_Activated" />
             </MenuItem>
             <MenuItem Header="Bookmarks">
                 <MenuItem Header="CefSharp Home" Name="homeMenuItem" />

--- a/CefSharp.Wpf.Example/MainWindow.xaml.cs
+++ b/CefSharp.Wpf.Example/MainWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace CefSharp.Wpf.Example
         public event EventHandler TestConsoleMessageActivated;
         public event EventHandler TestTooltipActivated;
         public event EventHandler TestPopupActivated;
+        public event EventHandler TestLoadStringActivated;
 
         // navigation
         public event Action<object, string> UrlActivated;
@@ -72,6 +73,7 @@ namespace CefSharp.Wpf.Example
                 { testConsoleMessageMenuItem, TestConsoleMessageActivated },
                 { testTooltipMenuItem, TestTooltipActivated },
                 { testPopupMenuItem, TestPopupActivated },
+                { testLoadStringItem, TestLoadStringActivated },
 
                 // navigation
                 { backButton, BackActivated },

--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -246,6 +246,13 @@ namespace Wpf
         _clientAdapter->GetCefBrowser()->GetMainFrame()->LoadURL(toNative(url));
     }
 
+    void WebView::LoadHtml(String^ html)
+    {
+        _browserCore->CheckBrowserInitialization();
+        _browserCore->OnLoad();
+        _clientAdapter->GetCefBrowser()->GetMainFrame()->LoadString(toNative(html), toNative("about:blank"));
+    }
+
     void WebView::Stop()
     {
         _browserCore->CheckBrowserInitialization();

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -174,6 +174,7 @@ namespace Wpf
         virtual void OnInitialized();
 
         virtual void Load(String^ url);
+        virtual void LoadHtml(String^ html);
         virtual void Stop();
         virtual void Back();
         virtual void Forward();

--- a/CefSharp/IWebBrowser.h
+++ b/CefSharp/IWebBrowser.h
@@ -38,6 +38,7 @@ namespace CefSharp
         void OnInitialized();
 
         void Load(String^ url);
+        void LoadHtml(String^ html);
         void Stop();
         void Back();
         void Forward();


### PR DESCRIPTION
Fully prepared to have this rejected : )

Basically I added a little bit of code to allow for invoking `LoadString()` on the CEF control.

It works, and I added a added a test method to the two example apps, but there are a few "issues" remaining to be aware of:
1.  I wanted to keep the naming consistent by using `LoadString()` everywhere.  However, as far as I can tell, this clashed with the `LoadString`/`LoadStringW` defined in winuser.h and I've no idea how to work around this : ).  Instead I named it `LoadHtml`.
2.  The CEF control appears to require a valid URL to be included with `LoadString()`.  For my needs, I don't need this and hardcoded `about:blank`.  If necessary I can change the definition to allow a user to specify a value.
3. The file `CefSharp.WinForms.Example/Browser.Designer.cs` was changed a bunch by the Visual Studio designer.  Again, something I can work around if needed.
