### PR TITLE
Handling errors in the page load

### DIFF
--- a/CefSharp/ClientAdapter.cpp
+++ b/CefSharp/ClientAdapter.cpp
@@ -118,8 +118,23 @@ namespace CefSharp
     bool ClientAdapter::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& failedUrl, CefString& errorText)
     {
         IAfterLoadError^ handler = _browserControl->AfterLoadErrorHandler;
-        return handler != nullptr &&
-            handler->HandleLoadError();
+        if (handler == nullptr)
+        {
+            return false;
+        }
+
+        String^ errorString = nullptr;
+        handler->HandleLoadError(_browserControl, errorCode, toClr(failedUrl), errorString);
+
+        if (errorString == nullptr)
+        {
+            return false;
+        }
+        else
+        {
+            errorText = toNative(errorString);
+            return true;
+        }
     }
 
     bool ClientAdapter::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, NavType navType, bool isRedirect)

--- a/CefSharp/ClientAdapter.cpp
+++ b/CefSharp/ClientAdapter.cpp
@@ -186,14 +186,29 @@ namespace CefSharp
     void ClientAdapter::OnResourceResponse(CefRefPtr<CefBrowser> browser, const CefString& url, CefRefPtr<CefResponse> response, CefRefPtr<CefContentFilter>& filter)
     {
         IAfterResponse^ handler = _browserControl->AfterResponseHandler;
-        if (handler != nullptr)
+        if (handler == nullptr)
         {
-            String^ cookie = toClr(response->GetHeader("Set-Cookie"));
-            if (!String::IsNullOrEmpty(cookie))
-            {
-                handler->HandleSetCookie(cookie);
-            }
+            return;
         }
+
+        IList<Header^>^ headers = gcnew List<Header^>();
+        CefResponse::HeaderMap hm;
+        response->GetHeaderMap(hm);
+        for (CefResponse::HeaderMap::iterator it = hm.begin(); it != hm.end(); ++it)
+        {
+            Header^ header = gcnew Header();
+            header->name = toClr(it->first);
+            header->value = toClr(it->second);
+            headers->Add(header);
+        }
+
+        handler->HandleResponse(
+            _browserControl,
+            toClr(url),
+            response->GetStatus(),
+            toClr(response->GetStatusText()),
+            toClr(response->GetMimeType()),
+            headers);
     }
 
     void ClientAdapter::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefV8Context> context)

--- a/CefSharp/IAfterLoadError.h
+++ b/CefSharp/IAfterLoadError.h
@@ -6,6 +6,6 @@ namespace CefSharp
     public interface class IAfterLoadError
     {
     public:
-        bool HandleLoadError();
+        void HandleLoadError(IWebBrowser^ browser, int errorCode, String^ failedUrl, String^% errorText);
     };
 }

--- a/CefSharp/IAfterResponse.h
+++ b/CefSharp/IAfterResponse.h
@@ -5,9 +5,16 @@ using namespace System;
 
 namespace CefSharp
 {
+    public ref struct Header
+    {
+    public:
+        String^ name;
+        String^ value;
+    };
+
     public interface class IAfterResponse
     {
     public:
-        void HandleSetCookie(String^ cookie);
+        void HandleResponse(IWebBrowser^ browser, String^ url, int status, String^ statusText, String^ mimeType, IList<Header^>^ headers);
     };
 }

--- a/CefSharp/ScriptCore.cpp
+++ b/CefSharp/ScriptCore.cpp
@@ -5,14 +5,37 @@
 
 namespace CefSharp
 {
+    bool TryGetMainFrame(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>& mainFrame)
+    {
+        if (browser != nullptr)
+        {
+            mainFrame = browser->GetMainFrame();
+            return mainFrame != nullptr;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     void ScriptCore::UIT_Execute(CefRefPtr<CefBrowser> browser, CefString script)
     {
-        browser->GetMainFrame()->ExecuteJavaScript(script, "about:blank", 0);
+        CefRefPtr<CefFrame> mainFrame;
+        if (TryGetMainFrame(browser, mainFrame))
+        {
+            mainFrame->ExecuteJavaScript(script, "about:blank", 0);
+        }
     }
 
     void ScriptCore::UIT_Evaluate(CefRefPtr<CefBrowser> browser, CefString script)
     {
-        CefRefPtr<CefV8Context> context = browser->GetMainFrame()->GetV8Context();
+        CefRefPtr<CefFrame> mainFrame;
+        if (!TryGetMainFrame(browser, mainFrame))
+        {
+            return;
+        }
+
+        CefRefPtr<CefV8Context> context = mainFrame->GetV8Context();
 
         if (context.get() &&
             context->Enter())


### PR DESCRIPTION
I've been able to build the error handling I wanted using these two interfaces. The HandleResponse part requires that I distinguish between errors from the page URL itself, and errors from the resources URLs it loads. Right now I'm just comparing the error URL to the URL I know I'm navigating to, which is kind of a hack, but it's working.

My C++ fu is really weak, so please correct me if I'm doing any of the memory management wrong, or if there are better idioms I could be using.
