### PR TITLE
Raise a 'LoadCompleted' event when OnFrameLoadEnd is called

### DIFF
--- a/CefSharp.WinForms/WebView.cpp
+++ b/CefSharp.WinForms/WebView.cpp
@@ -327,14 +327,17 @@ namespace WinForms
         ConsoleMessage(this, gcnew ConsoleMessageEventArgs(message, source, line));
     }
 
-    void WebView::OnFrameLoadStart()
+    void WebView::OnFrameLoadStart(String^ url)
     {
         _browserCore->OnFrameLoadStart();
     }
 
-    void WebView::OnFrameLoadEnd()
+    void WebView::OnFrameLoadEnd(String^ url)
     {
         _browserCore->OnFrameLoadEnd();
+        
+        LoadCompletedEventArgs^ args = gcnew LoadCompletedEventArgs(url);
+        LoadCompleted(this, args);
     }
 
     void WebView::OnTakeFocus(bool next)

--- a/CefSharp.WinForms/WebView.h
+++ b/CefSharp.WinForms/WebView.h
@@ -46,6 +46,7 @@ namespace WinForms
 
         virtual event ConsoleMessageEventHandler^ ConsoleMessage;
         virtual event KeyEventHandler^ BrowserKey;
+        virtual event LoadCompletedEventHandler^ LoadCompleted;
 
         WebView()
         {
@@ -179,8 +180,8 @@ namespace WinForms
 
         virtual void SetNavState(bool isLoading, bool canGoBack, bool canGoForward);
 
-        virtual void OnFrameLoadStart();
-        virtual void OnFrameLoadEnd();
+        virtual void OnFrameLoadStart(String^ url);
+        virtual void OnFrameLoadEnd(String^ url);
         virtual void OnTakeFocus(bool next);
         virtual void OnConsoleMessage(String^ message, String^ source, int line);
 

--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -544,14 +544,17 @@ namespace Wpf
         return _browserCore->GetBoundObjects();
     }
 
-    void WebView::OnFrameLoadStart()
+    void WebView::OnFrameLoadStart(String^ url)
     {
         _browserCore->OnFrameLoadStart();
     }
 
-    void WebView::OnFrameLoadEnd()
+    void WebView::OnFrameLoadEnd(String^ url)
     {
         _browserCore->OnFrameLoadEnd();
+
+        LoadCompletedEventArgs^ args = gcnew LoadCompletedEventArgs(url);
+        LoadCompleted(this, args);
     }
 
     void WebView::OnTakeFocus(bool next)

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -84,6 +84,7 @@ namespace Wpf
 
         virtual event ConsoleMessageEventHandler^ ConsoleMessage;
         virtual event KeyEventHandler^ BrowserKey;
+        virtual event LoadCompletedEventHandler^ LoadCompleted;
 
         WebView()
         {
@@ -217,8 +218,8 @@ namespace Wpf
 
         virtual void SetNavState(bool isLoading, bool canGoBack, bool canGoForward);
 
-        virtual void OnFrameLoadStart();
-        virtual void OnFrameLoadEnd();
+        virtual void OnFrameLoadStart(String^ url);
+        virtual void OnFrameLoadEnd(String^ url);
         virtual void OnTakeFocus(bool next);
         virtual void OnConsoleMessage(String^ message, String^ source, int line);
 

--- a/CefSharp/CefSharp.vcproj
+++ b/CefSharp/CefSharp.vcproj
@@ -319,6 +319,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\LoadCompletedEventArgs.h"
+				>
+			</File>
+			<File
 				RelativePath=".\MCefRefPtr.h"
 				>
 			</File>

--- a/CefSharp/ClientAdapter.cpp
+++ b/CefSharp/ClientAdapter.cpp
@@ -112,7 +112,7 @@ namespace CefSharp
             _browserControl->SetNavState(true, false, false);
         }
 
-        _browserControl->OnFrameLoadStart();
+        _browserControl->OnFrameLoadStart(toClr(frame->GetURL()));
     }
 
     void ClientAdapter::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode)
@@ -128,7 +128,7 @@ namespace CefSharp
             _browserControl->SetNavState(false, browser->CanGoBack(), browser->CanGoForward());
         }
 
-        _browserControl->OnFrameLoadEnd();
+        _browserControl->OnFrameLoadEnd(toClr(frame->GetURL()));
     }
 
     bool ClientAdapter::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& failedUrl, CefString& errorText)

--- a/CefSharp/IWebBrowser.h
+++ b/CefSharp/IWebBrowser.h
@@ -3,6 +3,7 @@
 
 #include "BrowserCore.h"
 #include "ConsoleMessageEventArgs.h"
+#include "LoadCompletedEventArgs.h"
 
 using namespace System;
 using namespace System::ComponentModel;
@@ -62,8 +63,8 @@ namespace CefSharp
 
         void SetNavState(bool isLoading, bool canGoBack, bool canGoForward);
 
-        void OnFrameLoadStart();
-        void OnFrameLoadEnd();
+        void OnFrameLoadStart(String^ url);
+        void OnFrameLoadEnd(String^ url);
         void OnTakeFocus(bool next);
         void OnConsoleMessage(String^ message, String^ source, int line);
 

--- a/CefSharp/LoadCompletedEventArgs.h
+++ b/CefSharp/LoadCompletedEventArgs.h
@@ -1,0 +1,20 @@
+#include "stdafx.h"
+#pragma once
+
+using namespace System;
+
+namespace CefSharp
+{
+    public ref class LoadCompletedEventArgs : EventArgs
+    {
+        String^ _url;
+
+    public:
+        LoadCompletedEventArgs(String^ url)
+            : _url(url) {}
+
+        property String^ Url { String^ get() { return _url; } }
+    };
+
+    public delegate void LoadCompletedEventHandler(Object^ sender, LoadCompletedEventArgs^ url);
+}


### PR DESCRIPTION
Implemented a 'LoadCompleted' event to mirror the behavior provided by the WinForms & WPF WebBrowser controls.
