### PR TITLE
Types defined in wrong assemblies

### DIFF
--- a/CefSharp.WinForms/WebView.cpp
+++ b/CefSharp.WinForms/WebView.cpp
@@ -49,7 +49,7 @@ namespace WinForms
             window.SetAsChild(hWnd, rect);
 
             CefBrowser::CreateBrowser(window, _clientAdapter.get(),
-                url, *_settings->_browserSettings);
+                url, *(CefBrowserSettings*)_settings->_internalBrowserSettings);
         }
     }
 

--- a/CefSharp.WinForms/WebView.h
+++ b/CefSharp.WinForms/WebView.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "BrowserSettings.h"
 #include "ClientAdapter.h"
 #include "ScriptCore.h"
 

--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -609,7 +609,7 @@ namespace Wpf
         CefString url = toNative(_browserCore->Address);
 
         CefBrowser::CreateBrowser(window, _clientAdapter.get(),
-            url, *_settings->_browserSettings);
+            url, *(CefBrowserSettings*)_settings->_internalBrowserSettings);
 
         Content = _image = gcnew Image();
 

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "BrowserSettings.h"
 #include "RenderClientAdapter.h"
 #include "ScriptCore.h"
     

--- a/CefSharp/BrowserSettings.cpp
+++ b/CefSharp/BrowserSettings.cpp
@@ -1,5 +1,4 @@
-#include "stdafx.h"
-#pragma once
+#include "StdAfx.h"
 
 namespace CefSharp
 {
@@ -12,6 +11,13 @@ namespace CefSharp
         BrowserSettings() : _browserSettings(new CefBrowserSettings()) { }
         !BrowserSettings() { delete _browserSettings; }
         ~BrowserSettings() { delete _browserSettings; }
+
+        // CefBrowserSettings is private causing whole field to be private
+        // exposing void* as a workaround
+        property void* _internalBrowserSettings
+        {
+            void* get() { return _browserSettings; }
+        }
 
         property bool DragDropDisabled
         {

--- a/CefSharp/CefSharp.vcproj
+++ b/CefSharp/CefSharp.vcproj
@@ -199,6 +199,9 @@
 			<File
 				RelativePath=".\BrowserCore.cpp"
 				>
+			<File
+				RelativePath=".\BrowserSettings.cpp"
+				>
 			</File>
 			<File
 				RelativePath=".\ClientAdapter.cpp"
@@ -276,10 +279,6 @@
 			</File>
 			<File
 				RelativePath=".\BrowserCore.h"
-				>
-			</File>
-			<File
-				RelativePath=".\BrowserSettings.h"
 				>
 			</File>
 			<File

--- a/CefSharp/CefSharp.vcproj
+++ b/CefSharp/CefSharp.vcproj
@@ -199,6 +199,7 @@
 			<File
 				RelativePath=".\BrowserCore.cpp"
 				>
+			</File>
 			<File
 				RelativePath=".\BrowserSettings.cpp"
 				>

--- a/CefSharp/ScriptCore.h
+++ b/CefSharp/ScriptCore.h
@@ -3,7 +3,7 @@
 
 namespace CefSharp
 {
-    public class ScriptCore
+    class ScriptCore
     {
     private:
         HANDLE _event;


### PR DESCRIPTION
Following types should be defined CefSharp.dll:
- CefSharp.BrowserSettings
- CefSharp.ScriptCore

but instead end up in CefSharp.WinForms.dll and CefSharp.Wpf.dll. In fact ScriptCore is duplicated everywhere.

This makes it problematic when both dlls are referenced.

In case of BrowserSettings it's probably caused by the fact that a ref class definition is being included instead of referenced with "using" and the source file shouldn't be a header at all.
CefSharp.ScriptCore should be somehow marked as native type, perhaps pragma managed(push,off).

Unfortunately I was unable to get it to compile with suggested changes.
