### PR TITLE
When WPF WebView is removed from one window and added to another, keyboard input is lost.

### DIFF
--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -83,6 +83,9 @@ namespace Wpf
         void OnPopupMouseUp(Object^ sender, MouseButtonEventArgs^ e) ;
         void OnPopupMouseLeave(Object^ sender, MouseEventArgs^ e) ;
         void OnWindowLocationChanged(Object^ sender, EventArgs^ e) ;
+        void OnLoaded(Object^ sender, RoutedEventArgs^ e) ;
+        void OnUnloaded(Object^ sender, RoutedEventArgs^ e) ;
+        void EnsureSourceAndHook();
         void HidePopup();
 		
     protected:


### PR DESCRIPTION
The reason for this is that the the message loop hook that the WPF view uses, is not updated when the main presentation source is changed - the control is moved from one window to another.
