### PR TITLE
Fix wpf web view popup image dimensions

### DIFF
--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -171,9 +171,9 @@ namespace Wpf
             _popupImage->Source = nullptr;
             GC::Collect(1);
 
-            int stride = _popupWidth * PixelFormats::Bgr32.BitsPerPixel / 8;
+            int stride = _popupImageWidth * PixelFormats::Bgr32.BitsPerPixel / 8;
             bitmap = (InteropBitmap^)Interop::Imaging::CreateBitmapSourceFromMemorySection(
-                (IntPtr)_popupFileMappingHandle, _popupWidth, _popupHeight, PixelFormats::Bgr32, stride, 0);
+                (IntPtr)_popupFileMappingHandle, _popupImageWidth, _popupImageHeight, PixelFormats::Bgr32, stride, 0);
             _popupImage->Source = bitmap;
             _popupIbitmap = bitmap;
         }
@@ -685,7 +685,7 @@ namespace Wpf
 
     void WebView::SetPopupBuffer(int width, int height, const void* buffer)
     {
-        int currentWidth = _popupWidth, currentHeight = _popupHeight;
+        int currentWidth = _popupImageWidth, currentHeight = _popupImageHeight;
         HANDLE fileMappingHandle = _popupFileMappingHandle, backBufferHandle = _popupBackBufferHandle;
         InteropBitmap^ ibitmap = _popupIbitmap;
 
@@ -696,8 +696,8 @@ namespace Wpf
         _popupFileMappingHandle = fileMappingHandle;
         _popupBackBufferHandle = backBufferHandle;
 
-        _popupWidth = currentWidth;
-        _popupHeight = currentHeight;
+        _popupImageWidth = currentWidth;
+        _popupImageHeight = currentHeight;
     }
 
     void WebView::SetBuffer(int &currentWidth, int& currentHeight, int width, int height,

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -83,6 +83,9 @@ namespace Wpf
         void OnPopupMouseUp(Object^ sender, MouseButtonEventArgs^ e) ;
         void OnPopupMouseLeave(Object^ sender, MouseEventArgs^ e) ;
         void OnWindowLocationChanged(Object^ sender, EventArgs^ e) ;
+        void OnLoaded(Object^ sender, RoutedEventArgs^ e) ;
+        void OnUnloaded(Object^ sender, RoutedEventArgs^ e) ;
+        void EnsureSourceAndHook();
         void HidePopup();
 		
     protected:

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -50,6 +50,7 @@ namespace Wpf
         
         Image^ _popupImage;
         int _popupWidth, _popupHeight, _popupX, _popupY;
+        int _popupImageWidth, _popupImageHeight;
         InteropBitmap^ _popupIbitmap;
         HANDLE _popupFileMappingHandle, _popupBackBufferHandle;
         ActionHandler^ _paintPopupDelegate;

--- a/CefSharp/ClientAdapter.cpp
+++ b/CefSharp/ClientAdapter.cpp
@@ -11,6 +11,8 @@
 #include "IMenuHandler.h"
 #include "IKeyboardHandler.h"
 
+using namespace std;
+
 namespace CefSharp
 {
     bool ClientAdapter::OnBeforePopup(CefRefPtr<CefBrowser> parentBrowser, const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo, const CefString& url, CefRefPtr<CefClient>& client, CefBrowserSettings& settings)
@@ -187,8 +189,21 @@ namespace CefSharp
         else if (requestResponse->Action == ResponseAction::Respond)
         {
             CefRefPtr<StreamAdapter> adapter = new StreamAdapter(requestResponse->ResponseStream);
+
             resourceStream = CefStreamReader::CreateForHandler(static_cast<CefRefPtr<CefReadHandler>>(adapter));
             response->SetMimeType(toNative(requestResponse->MimeType));
+			response->SetStatus(requestResponse->StatusCode);
+			response->SetStatusText(toNative(requestResponse->StatusText));
+
+			CefResponse::HeaderMap map;
+			if(requestResponse->ResponseHeaders != nullptr)
+			{
+				for each(KeyValuePair<String^, String^>^ kvp in requestResponse->ResponseHeaders)
+				{
+					map.insert(pair<CefString,CefString>(toNative(kvp->Key),toNative(kvp->Value)));
+				}
+			}
+			response->SetHeaderMap(map);
         }
 
         return ret;

--- a/CefSharp/RequestResponse.cpp
+++ b/CefSharp/RequestResponse.cpp
@@ -13,8 +13,12 @@ namespace CefSharp
         _redirectUrl = url;
         _action = ResponseAction::Redirect;
     }
-
+	
     void RequestResponse::RespondWith(Stream^ stream, String^ mimeType)
+    {
+		RespondWith(stream, mimeType, "OK", 200, nullptr);
+	}
+    void RequestResponse::RespondWith(Stream^ stream, String^ mimeType, String^ statusText, int statusCode, IDictionary<String^, String^>^ responseHeaders)
     {
         if(String::IsNullOrEmpty(mimeType))
         {
@@ -28,6 +32,10 @@ namespace CefSharp
 
         _responseStream = stream;
         _mimeType = mimeType;
+		_statusText = statusText;
+		_statusCode = statusCode;
+		_responseHeaders = responseHeaders;
+
         _action = ResponseAction::Respond;
     }
 }

--- a/CefSharp/RequestResponse.h
+++ b/CefSharp/RequestResponse.h
@@ -36,6 +36,9 @@ namespace CefSharp
         String^ _mimeType;
         String^ _redirectUrl;
         ResponseAction _action;
+        String^ _statusText;
+		int _statusCode;
+		IDictionary<String^, String^>^ _responseHeaders;
 
     internal:
         RequestResponse(IRequest^ request) :
@@ -44,6 +47,9 @@ namespace CefSharp
 
         property Stream^ ResponseStream { Stream^ get() { return _responseStream; } }
         property String^ MimeType { String^ get() { return _mimeType; } }
+		property String^ StatusText { String^ get() { return _statusText; } }
+		property int StatusCode { int get() { return _statusCode; } }
+		property IDictionary<String^, String^>^ ResponseHeaders { IDictionary<String^, String^>^ get() { return _responseHeaders; } }
         property String^ RedirectUrl { String^ get() { return _redirectUrl; } }
         property ResponseAction Action { ResponseAction get() { return _action; } }
 
@@ -52,6 +58,7 @@ namespace CefSharp
         virtual property IRequest^ Request { IRequest^ get() { return _request; } }
         virtual void Redirect(String^ url);
         virtual void RespondWith(Stream^ stream, String^ mimeType);
+        virtual void RespondWith(Stream^ stream, String^ mimeType, String^ statusText, int statusCode, IDictionary<String^, String^>^ responseHeaders);
     };
 
 }


### PR DESCRIPTION
Fixes AccessViolationException. SetPopupBuffer used _popupWidth and _popupHeight that were previously changed to the new values by SetPopupSizeAndPosition. Because of this, the handles in SetBuffer were not released which caused AccessViolationException
