### PR TITLE
ClientAdapter is now CefJSDialogHandler

### DIFF
--- a/CefSharp.WinForms/WebView.h
+++ b/CefSharp.WinForms/WebView.h
@@ -146,6 +146,12 @@ namespace WinForms
             void set(IKeyboardHandler^ handler) { _browserCore->KeyboardHandler = handler; }
         }
 
+        virtual property IJsDialogHandler^ JsDialogHandler
+        {
+            IJsDialogHandler^ get() { return _browserCore->JsDialogHandler; }
+            void set(IJsDialogHandler^ handler) { _browserCore->JsDialogHandler = handler; }
+        }
+
         virtual void OnInitialized();
 
         virtual void Load(String^ url);

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -225,6 +225,12 @@ namespace Wpf
             void set(IKeyboardHandler^ handler) { _browserCore->KeyboardHandler = handler; }
         }
 
+        virtual property IJsDialogHandler^ JsDialogHandler
+        {
+            IJsDialogHandler^ get() { return _browserCore->JsDialogHandler; }
+            void set(IJsDialogHandler^ handler) { _browserCore->JsDialogHandler = handler; }
+        }
+
         virtual void OnInitialized();
 
         virtual void Load(String^ url);

--- a/CefSharp/BrowserCore.h
+++ b/CefSharp/BrowserCore.h
@@ -14,6 +14,7 @@ namespace CefSharp
     interface class IRequestHandler;
     interface class IMenuHandler;
     interface class IKeyboardHandler;
+    interface class IJsDialogHandler;
 
     public ref class BrowserCore : INotifyPropertyChanged
     {
@@ -37,6 +38,7 @@ namespace CefSharp
         IRequestHandler^ _requestHandler;
         IMenuHandler^ _menuHandler;
         IKeyboardHandler^ _keyboardHandler;
+        IJsDialogHandler^ _jsDialogHandler;
 
         IDictionary<String^, Object^>^ _boundObjects;
 
@@ -170,6 +172,12 @@ namespace CefSharp
         {
             IKeyboardHandler^ get() { return _keyboardHandler; }
             void set(IKeyboardHandler^ handler) { _keyboardHandler = handler; }
+        }
+
+        virtual property IJsDialogHandler^ JsDialogHandler
+        {
+            IJsDialogHandler^ get() { return _jsDialogHandler; }
+            void set(IJsDialogHandler^ handler) { _jsDialogHandler = handler; }
         }
 
         void CheckBrowserInitialization();

--- a/CefSharp/CefSharp.vcproj
+++ b/CefSharp/CefSharp.vcproj
@@ -315,6 +315,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\IJsDialogHandler.h"
+				>
+			</File>
+			<File
 				RelativePath=".\IKeyboardHandler.h"
 				>
 			</File>

--- a/CefSharp/ClientAdapter.cpp
+++ b/CefSharp/ClientAdapter.cpp
@@ -11,6 +11,7 @@
 #include "IRequestHandler.h"
 #include "IMenuHandler.h"
 #include "IKeyboardHandler.h"
+#include "IJsDialogHandler.h"
 
 using namespace std;
 
@@ -319,5 +320,51 @@ namespace CefSharp
     void ClientAdapter::OnTakeFocus(CefRefPtr<CefBrowser> browser, bool next)
     {
         _browserControl->OnTakeFocus(next);
+    }
+
+    bool ClientAdapter::OnJSAlert(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& message)
+    {
+        IJsDialogHandler^ handler = _browserControl->JsDialogHandler;
+        if (handler == nullptr)
+        {
+            return false;
+        }
+
+        bool handled = handler->OnJSAlert(_browserControl, toClr(frame->GetURL()), toClr(message));
+
+        return handled;
+    }
+
+    bool ClientAdapter::OnJSConfirm(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& message, bool& retval)
+    {
+        IJsDialogHandler^ handler = _browserControl->JsDialogHandler;
+        if (handler == nullptr)
+        {
+            return false;
+        }
+
+        bool handled = handler->OnJSConfirm(_browserControl, toClr(frame->GetURL()), toClr(message), retval);
+
+        return handled;
+    }
+
+    bool ClientAdapter::OnJSPrompt(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& message, const CefString& defaultValue, bool& retval, CefString& result)
+    {
+        IJsDialogHandler^ handler = _browserControl->JsDialogHandler;
+        if (handler == nullptr)
+        {
+            return false;
+        }
+
+        String^ resultString = nullptr;
+
+        bool handled = handler->OnJSPrompt(_browserControl, toClr(frame->GetURL()), toClr(message), toClr(defaultValue), retval, resultString);
+
+        if(resultString != nullptr)
+        {
+            result = toNative(resultString);
+        }
+
+        return handled;
     }
 }

--- a/CefSharp/ClientAdapter.h
+++ b/CefSharp/ClientAdapter.h
@@ -17,7 +17,8 @@ namespace CefSharp
                           public CefV8ContextHandler,
                           public CefMenuHandler,
                           public CefFocusHandler,
-                          public CefKeyboardHandler
+                          public CefKeyboardHandler,
+                          public CefJSDialogHandler
     {
     private:
         gcroot<IWebBrowser^> _browserControl;
@@ -42,6 +43,7 @@ namespace CefSharp
         virtual CefRefPtr<CefMenuHandler> GetMenuHandler() OVERRIDE { return this; }
         virtual CefRefPtr<CefFocusHandler> GetFocusHandler() OVERRIDE { return this; }
         virtual CefRefPtr<CefKeyboardHandler> GetKeyboardHandler() OVERRIDE { return this; }
+        virtual CefRefPtr<CefJSDialogHandler> GetJSDialogHandler() OVERRIDE { return this; }
 
         // CefLifeSpanHandler
         virtual DECL bool OnBeforePopup(CefRefPtr<CefBrowser> parentBrowser, const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo, const CefString& url, CefRefPtr<CefClient>& client, CefBrowserSettings& settings) OVERRIDE;
@@ -79,6 +81,11 @@ namespace CefSharp
 
         // CefKeyboardHandler
         virtual DECL bool OnKeyEvent(CefRefPtr<CefBrowser> browser, KeyEventType type, int code, int modifiers, bool isSystemKey, bool isAfterJavaScript) OVERRIDE;
+
+        // CefJSDialogHandler
+        virtual DECL bool OnJSAlert(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& message) OVERRIDE;
+        virtual DECL bool OnJSConfirm(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& message, bool& retval) OVERRIDE;
+        virtual DECL bool OnJSPrompt(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& message, const CefString& defaultValue, bool& retval,  CefString& result) OVERRIDE;
 
         IMPLEMENT_LOCKING(ClientAdapter);
         IMPLEMENT_REFCOUNTING(ClientAdapter);

--- a/CefSharp/IJsDialogHandler.h
+++ b/CefSharp/IJsDialogHandler.h
@@ -1,0 +1,14 @@
+#pragma once
+
+using namespace System;
+
+namespace CefSharp
+{
+    public interface class IJsDialogHandler
+    {
+        public:
+            bool OnJSAlert(IWebBrowser^ browser, String^ url, String^ message);
+            bool OnJSConfirm(IWebBrowser^ browser, String^ url, String^ message, bool& retval);
+            bool OnJSPrompt(IWebBrowser^ browser, String^ url, String^ message, String^ defaultValue, bool& retval,  String^% result);
+   };
+}

--- a/CefSharp/IWebBrowser.h
+++ b/CefSharp/IWebBrowser.h
@@ -15,6 +15,7 @@ namespace CefSharp
     interface class IRequestHandler;
     interface class IMenuHandler;
     interface class IKeyboardHandler;
+    interface class IJsDialogHandler;
 
     public interface class IWebBrowser : IDisposable, INotifyPropertyChanged
     {
@@ -38,6 +39,7 @@ namespace CefSharp
         property IRequestHandler^ RequestHandler;
         property IMenuHandler^ MenuHandler;
         property IKeyboardHandler^ KeyboardHandler;
+        property IJsDialogHandler^ JsDialogHandler;
 
         void OnInitialized();
 


### PR DESCRIPTION
Make ClientAdapter CefJSDialogHandler. Methods call propagate to WebView and then BrowserCore. This way we could override WebView and provide custom implementation for some of the CefJSDialogHandler methods.
