### PR TITLE
Stop the tooltip timer on mouse leave

### DIFF
--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -344,6 +344,7 @@ namespace Wpf
             browser->SendMouseMoveEvent(0, 0, true);
         }
 
+        _timer->Stop();
         _toolTip->IsOpen = false;
     }
 


### PR DESCRIPTION
Prevents tooltip from appearing outside the browser and getting stuck (e.g. when user quickly moves the mouse outside the browser window after hovering over an element that has tooltip).
