### PR TITLE
Move the subscription to LocationChanged and Deactivated Window events to OnLoaded.

### DIFF
--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -241,12 +241,6 @@ namespace Wpf
             }
         }
 
-        window = Window::GetWindow(this);
-        if (window != nullptr)
-        {
-            window->LocationChanged += _handler;
-            window->Deactivated += _handler;
-        }
 
         ContentControl::OnVisualParentChanged(oldParent);
     }
@@ -814,6 +808,16 @@ namespace Wpf
     void WebView::OnLoaded(Object^ sender, RoutedEventArgs^ e)
     {
         AddSourceHook();
+
+        EventHandler^ _handler = gcnew EventHandler(this, &WebView::OnHidePopup);
+        Window^ window;
+
+        window = Window::GetWindow(this);
+        if (window != nullptr)
+        {
+            window->LocationChanged += _handler;
+            window->Deactivated += _handler;
+        }
     }
 
     void WebView::OnUnloaded(Object^ sender, RoutedEventArgs^ e)

--- a/CefSharp.Wpf/WebView.cpp
+++ b/CefSharp.Wpf/WebView.cpp
@@ -226,25 +226,6 @@ namespace Wpf
             type, mouseUp, e->ClickCount);
     }
 
-    void WebView::OnVisualParentChanged(DependencyObject^ oldParent)
-    {
-        EventHandler^ _handler = gcnew EventHandler(this, &WebView::OnHidePopup);
-        Window^ window;
-
-        if (oldParent != nullptr)
-        {
-            window = Window::GetWindow(oldParent);
-            if (window != nullptr)
-            {
-                window->LocationChanged -= _handler;
-                window->Deactivated -= _handler;
-            }
-        }
-
-
-        ContentControl::OnVisualParentChanged(oldParent);
-    }
-
     Size WebView::ArrangeOverride(Size size)
     {
         CefRefPtr<CefBrowser> browser;
@@ -810,18 +791,25 @@ namespace Wpf
         AddSourceHook();
 
         EventHandler^ _handler = gcnew EventHandler(this, &WebView::OnHidePopup);
-        Window^ window;
 
-        window = Window::GetWindow(this);
-        if (window != nullptr)
+        currentWindow = Window::GetWindow(this);
+        if (currentWindow != nullptr)
         {
-            window->LocationChanged += _handler;
-            window->Deactivated += _handler;
+            currentWindow->LocationChanged += _handler;
+            currentWindow->Deactivated += _handler;
         }
     }
 
     void WebView::OnUnloaded(Object^ sender, RoutedEventArgs^ e)
     {  
+        EventHandler^ _handler = gcnew EventHandler(this, &WebView::OnHidePopup);
+
+        if (currentWindow != nullptr)
+        {
+            currentWindow->LocationChanged -= _handler;
+            currentWindow->Deactivated -= _handler;
+        }
+
         if (_source && _hook)
         {
             _source->RemoveHook(_hook);

--- a/CefSharp.Wpf/WebView.h
+++ b/CefSharp.Wpf/WebView.h
@@ -33,6 +33,7 @@ namespace Wpf
         BrowserCore^ _browserCore;
         MCefRefPtr<ScriptCore> _scriptCore;
 		
+        Window^ currentWindow;
         Object^ _sync;
         HwndSource^ _source;
         Matrix^ _matrix;
@@ -90,7 +91,6 @@ namespace Wpf
         void AddSourceHook();
 		
     protected:
-        virtual void OnVisualParentChanged(DependencyObject^ oldParent) override;
         virtual Size ArrangeOverride(Size size) override;
         virtual void OnGotFocus(RoutedEventArgs^ e) override;
         virtual void OnLostFocus(RoutedEventArgs^ e) override;


### PR DESCRIPTION
When you have one single WPF Window and its Content is a WebView, you could simulate reloading of the WebView, by disposing the old one and creating a new one. This causes the
`OnVisualParentChanged` to execute two times, for the old and new WebView. The Window is the same so the following code,  
`window->LocationChanged += _handler;
window->Deactivated += _handler;` 
executes two times. When the location of the Window changes the handler for the old, disposed view is invoked, which is incorrect and causes exceptions.
